### PR TITLE
Fix passing commandline arguments to clang

### DIFF
--- a/pkg/clang/clang.go
+++ b/pkg/clang/clang.go
@@ -308,14 +308,15 @@ func (idx Index) Parse(fname string, args []string, options TranslationUnitFlags
 		defer C.free(unsafe.Pointer(cstr))
 		c_cmds[i] = cstr
 	}
-	var c_args *C.char = nil
+	
+	var c_args **C.char = nil
 	if len(args) > 0 {
-		c_args = c_cmds[0]
+		c_args = &c_cmds[0]
 	}
 	o := C.clang_parseTranslationUnit(
 		idx.c,
 		c_fname,
-		&c_args, c_nargs,
+		c_args, c_nargs,
 		nil, C.uint(0), 
 		C.uint(options))
 	return TranslationUnit{o}


### PR DESCRIPTION
I was getting strange errors whenever I tried to pass arguments to clang. This patch fixes it.

They were of the form:

```
warning: p�@�: 'linker' input unused when '-fsyntax-only' is present
```

for each argument passed after the first one.
